### PR TITLE
fix: link to original language if no translation exists when gh-pages is true

### DIFF
--- a/piggy/templates/assignments/5-assignment.html
+++ b/piggy/templates/assignments/5-assignment.html
@@ -52,6 +52,10 @@
             {% endif %}
           {% else %}
             {% set level_meta = assignment.meta %}
+            {# GitHub Pages only: If a translation doesn't exist for the level, link to the default language #}
+            {% if "/lang/" in request.path %}
+              {% set link = request.path.split('/lang/')[0].split('/')[0:-1] | join('/') ~ "/" ~ link %}
+            {% endif %}
           {% endif %}
           {% if assignment.level | int == level | int %}
             <!-- Current Level (Non-clickable) -->


### PR DESCRIPTION
When scraping a translated assignment (`/lang/ger`) where some levels lack translations, the web scraper would copy the original language files into the `/lang/` folder instead of linking back to the originals. This could cause broken links and, as a side effect, append language information to the HTML class `nav-tooltip` due to a regex depending on correctly formatted links.

The problem affects instances running with GH-PAGES enabled, though that should only occur in conjunction with the web scraper.

**Example (error):**
```bash
Assignment_01_Level_1_-_Title.html
Assignment_01_Level_2_-_Title.html
Assignment_01_Level_1_-_Title/
--lang/
----ger.html
----Assignment_01_Level_2_-_Title.html # Not a translation!
```

**After PR:**
```bash
Assignment_01_Level_1_-_Title.html
Assignment_01_Level_2_-_Title.html
Assignment_01_Level_1_-_Title/
--lang/
----ger.html
```

A regex in the web scraper was interfering with the `nav-tooltip` class because links in the HTML pointed directly to `<document>` inside the `/lang` folder, instead of `../../<document>/lang/<language>`. After this PR, links without translations now correctly point to `../../<document>` (the original language).

**The regex in question:**
```python
if "/lang/" in link:
  lang = link.split("/lang/")[1].split("/")[0]
  html = re.sub(rf"""href=\"({link.split("Level")[0].split("/")[-1]}[^/]+)\"""", rf'href="../../\1/lang/{lang}"', html)
```