### PR TITLE
fix: unescape all tooltips (#208)

### DIFF
--- a/piggy/templates/assignments/5-assignment.html
+++ b/piggy/templates/assignments/5-assignment.html
@@ -74,7 +74,7 @@
             >
               {{ level_text }} {{ assignment.level }}
               <!-- Tooltip -->
-              <div class="nav-tooltip">{{ level_meta.title }}</div>
+              <div class="nav-tooltip">{{ level_meta.title | unescape }}</div>
             </a>
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
* Added suppot for cowboy language

* fix: link to original language if no translation exists when gh-pages is true (#204)

* fix: add html unescape filter and unescape tooltips

Resolves #206

* fix: unescape all tooltips

---------