### PR TITLE
fix: filter information topics from exercises (#231)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,7 +58,7 @@ jobs:
             --cache-from type=local,src=/tmp/.buildx-cache \
             --cache-to type=local,dest=/tmp/.buildx-cache,mode=max \
             --load .
-          docker compose -f docker-compose.pages.yml up -d --remove-orphans
+          docker compose -f docker-compose.pages.yml up -d --build --remove-orphans --force-recreate
 
       - name: Install dependencies
         run: uv pip install -r .github/workflows/requirements-pages.txt

--- a/piggy/templates/assignments/3-subject.html
+++ b/piggy/templates/assignments/3-subject.html
@@ -17,7 +17,7 @@
   %}
 
   {# everything that doesn't have a type should be treated as an exercise (default type) #}
-  {% set exercises = segment.items() | list_difference([assignments]) %}
+  {% set exercises = segment.items() | list_difference([assignments] + [informations]) %}
 
   {# INFORMATION #}
   {% if informations %}


### PR DESCRIPTION
* ci: change cache mode

* ci: update dockerignore

* ci: add cachebust

* ci: remove orphans

* ci: revert back from build-push, try compose caching shenanigans

* ci: use buildx

* ci: fix

* ci: remove local cache for more speed

* Revert "ci: remove local cache for more speed"

This reverts commit 8b10040aa8703096d43d91f60136758d4f256fdf.

* Update pages.yml

* fix: filter information topics from exercises