### PR TITLE
f (#239)

### DIFF
--- a/piggy/templates/partials/parts/og-tags.html
+++ b/piggy/templates/partials/parts/og-tags.html
@@ -28,7 +28,7 @@
   {% set ns.image = meta.thumbnail %}
 {% elif media_abspath and meta.thumbnail %}
   {# TODO: This is a bit of a hack and probably unintended... Not sure why "piggybank" is here... #}
-  {% set ns.image = request.host_url.rstrip('/') + media_abspath.replace("/piggybank", "") + "/" + meta.thumbnail + "." + img_fmt %}
+  {% set ns.image = request.host_url.rstrip('/') + media_abspath.replace("/piggybank", "").replace(" ","_") + "/" + meta.thumbnail + "." + img_fmt %}
 {% elif level_name %}
   {% set ns.image = url_for('api.generate_thumbnail', text=level_name, _external=True)+'?c=' + meta.topic.name %}
 {% elif ns.meta_exists %}


### PR DESCRIPTION
* ci: change cache mode

* ci: update dockerignore

* ci: add cachebust

* ci: remove orphans

* ci: revert back from build-push, try compose caching shenanigans

* ci: use buildx

* ci: fix

* ci: remove local cache for more speed

* Revert "ci: remove local cache for more speed"

This reverts commit 8b10040aa8703096d43d91f60136758d4f256fdf.

* Update pages.yml

* fix: filter information topics from exercises

* fix: filter information topics from exercises (#231) (#232)

* ci: change cache mode

* ci: update dockerignore

* ci: add cachebust

* ci: remove orphans

* ci: revert back from build-push, try compose caching shenanigans

* ci: use buildx

* ci: fix

* ci: remove local cache for more speed

* Revert "ci: remove local cache for more speed"

This reverts commit 8b10040aa8703096d43d91f60136758d4f256fdf.

* Update pages.yml

* fix: filter information topics from exercises

* fix: og tags

Resolves #234

* ci(fix): update scraper

* Update pages.yml

* fix: use old reliable meta.thumbnail on pages without media_abspath

* fix: thumbnails for og tags

* Update og-tags.html