### PR TITLE
Font size selection and Monospace font selection

### DIFF
--- a/piggy/static/css/styles.css
+++ b/piggy/static/css/styles.css
@@ -1,7 +1,7 @@
 :root {
-  --piggy-font-size: 15px;
+  --piggy-font-scale: 1;
 
-  font-size: var(--piggy-font-size);
+  font-size: 16px;
 
   font-family: "Noto Sans", sans-serif;
   font-optical-sizing: auto;
@@ -188,6 +188,37 @@
   letter-spacing: 0px;
 }
 
+/****************************\
+|*     FONT SIZE THEMES     *|
+\****************************/
+:root[data-font-size="xx-small"] {
+  --piggy-font-scale: 0.75;
+}
+
+:root[data-font-size="x-small"] {
+  --piggy-font-scale: 0.85;
+}
+
+:root[data-font-size="small"] {
+  --piggy-font-scale: 0.9;
+}
+
+:root[data-font-size="normal"] {
+  --piggy-font-scale: 1;
+}
+
+:root[data-font-size="large"] {
+  --piggy-font-scale: 1.25;
+}
+
+:root[data-font-size="x-large"] {
+  --piggy-font-scale: 1.5;
+}
+
+:root[data-font-size="xx-large"] {
+  --piggy-font-scale: 2.0;
+}
+
 /*****************************\
 |*     ELEMENT OVERRIDES     *|
 \*****************************/
@@ -208,11 +239,11 @@ h6 {
 }
 
 h1 {
-  font-size: 2.5rem;
+  font-size: calc(2.5rem * var(--piggy-font-scale));
 }
 
 h2 {
-  font-size: 1rem;
+  font-size: calc(1.5rem * var(--piggy-font-scale));
 }
 
 .main-container {
@@ -220,7 +251,7 @@ h2 {
   min-height: 100vh;
   color: var(--piggy-text-main);
   text-shadow: var(--piggy-shadow-text) 3px 3px 5px;
-  font-size: var(--piggy-font-size);
+  font-size: calc(1rem * var(--piggy-font-scale));
   padding-bottom: 5rem;
 }
 
@@ -238,29 +269,30 @@ h2 {
 }
 
 .main-title {
-  font-size: 3rem;
+  font-size: calc(3rem * var(--piggy-font-scale));
   word-wrap: break-word;
 }
 
 .page-title {
-  font-size: 3rem;
+  font-size: calc(3rem * var(--piggy-font-scale));
   word-wrap: break-word;
 }
 
 @media screen and (max-width: 800px) {
   .page-title {
-    font-size: 2.5rem;
+    font-size: calc(2.5rem * var(--piggy-font-scale));
   }
 }
 
 @media screen and (max-width: 600px) {
   .page-title {
-    font-size: 2.25rem;
+    font-size: calc(2.25rem * var(--piggy-font-scale));
     word-wrap: break-word;
   }
 }
 
 @media screen and (min-width: 800px) {
+
   /* Make header sticky on larger displays */
   header {
     position: sticky;
@@ -290,6 +322,8 @@ img[src*="#center"] {
   display: flex;
   align-items: center;
   justify-content: center;
+  width: calc(3rem * var(--piggy-font-scale));
+  height: calc(3rem * var(--piggy-font-scale));
 }
 
 #scroll-to-top-btn:hover {
@@ -303,9 +337,14 @@ body:has(#settings-menu.open) #scroll-to-top-btn {
   pointer-events: none;
 }
 
+#scroll-to-top-btn svg {
+  width: calc(1.75rem * var(--piggy-font-scale));
+  height: calc(1.75rem * var(--piggy-font-scale));
+}
+
 ol {
   list-style: decimal;
-  font-size: initial;
+  font-size: calc(1rem * var(--piggy-font-scale));
 }
 
 /*********************\
@@ -477,7 +516,7 @@ ol {
   word-break: break-word;
   padding: 0.75rem;
   margin: 0.5rem auto 0.5rem auto;
-  font-size: 1.1rem;
+  font-size: calc(1.1rem * var(--piggy-font-scale));
   text-align: center;
 }
 
@@ -507,7 +546,7 @@ ol {
   text-align: center;
   margin-bottom: 1.5rem;
   margin-top: 0;
-  font-size: 2rem;
+  font-size: calc(2rem * var(--piggy-font-scale));
 }
 
 .quick-access-columns {
@@ -532,7 +571,7 @@ ol {
 .quick-access-year-heading {
   border-bottom: 1px solid var(--piggy-neutral);
   color: var(--light);
-  font-size: 2.5rem;
+  font-size: calc(2.5rem * var(--piggy-font-scale));
   font-weight: 900;
   margin-bottom: 1rem;
   text-align: center;
@@ -555,7 +594,7 @@ ol {
 }
 
 .quick-access-study-direction {
-  font-size: 1.25rem;
+  font-size: calc(1.25rem * var(--piggy-font-scale));
   margin-bottom: 0;
 }
 
@@ -597,7 +636,7 @@ ol {
 }
 
 .quick-access-heading {
-  font-size: 2rem;
+  font-size: calc(2rem * var(--piggy-font-scale));
   font-weight: bold;
 }
 
@@ -605,7 +644,7 @@ ol {
 |*    TITLES    *|
 \****************/
 .assignment-title {
-  font-size: xx-large;
+  font-size: calc(2.5rem * var(--piggy-font-scale));
   font-weight: 600;
   text-align: center;
   padding-bottom: 0.2rem;
@@ -616,11 +655,9 @@ ol {
 \*****************/
 .card-container {
   position: relative;
-  background: linear-gradient(
-    45deg,
-    var(--piggy-card-start) 0%,
-    var(--piggy-card-end) 100%
-  );
+  background: linear-gradient(45deg,
+      var(--piggy-card-start) 0%,
+      var(--piggy-card-end) 100%);
   color: var(--piggy-text-card);
   transition:
     transform 0.1s ease,
@@ -641,6 +678,7 @@ ol {
 
 .card-title {
   color: var(--piggy-text-title);
+  font-size: calc(1.25rem * var(--piggy-font-scale));
   width: 100%;
   text-align: center;
 }
@@ -691,6 +729,7 @@ ol {
 .tag-box {
   margin: 2px 2px 2px 2px;
   box-shadow: inset 0px 0px 5px 0 var(--piggy-shadow-box);
+  font-size: calc(0.85rem * var(--piggy-font-scale));
   color: var(--piggy-text-tag);
   font-weight: 500;
 }
@@ -715,6 +754,7 @@ ol {
   border-radius: 2rem;
   height: max-content;
   white-space: nowrap;
+  font-size: calc(0.85rem * var(--piggy-font-scale));
 }
 
 .difficulty-icon {
@@ -734,27 +774,27 @@ ol {
 /* Potential extra styling for difficulties */
 /*
 .difficulty-1 {
-  filter: 
+  filter:
     drop-shadow(0.2rem 0.2rem 0 var(--difficulty-1-color));
 }
 
 .difficulty-2 {
-  filter: 
+  filter:
     drop-shadow(0.2rem 0.2rem 0 var(--difficulty-2-color));
 }
 
 .difficulty-3 {
-  filter: 
+  filter:
     drop-shadow(0.2rem 0.2rem 0 var(--difficulty-3-color));
 }
 
 .difficulty-4 {
-  filter: 
+  filter:
     drop-shadow(0.2rem 0.2rem 0 var(--difficulty-4-color));
 }
 
 .difficulty-5 {
-  filter: 
+  filter:
     drop-shadow(0.2rem 0.2rem 0 var(--difficulty-5-color));
 }
 */
@@ -802,13 +842,10 @@ ol {
 |*     ASSIGNMENT CARDS     *|
 \****************************/
 .card-assignment {
-  background: linear-gradient(
-    135deg,
-    var(--piggy-assignment-card-start) 0%,
-    var(--piggy-assignment-card-end) 100%
-  );
-  border: var(--piggy-card-border-width) solid
-    var(--piggy-assignment-card-border);
+  background: linear-gradient(135deg,
+      var(--piggy-assignment-card-start) 0%,
+      var(--piggy-assignment-card-end) 100%);
+  border: var(--piggy-card-border-width) solid var(--piggy-assignment-card-border);
   padding: 0.75rem;
 }
 
@@ -833,13 +870,10 @@ ol {
 \***************************/
 
 .card-information {
-  background: linear-gradient(
-    135deg,
-    var(--piggy-information-card-start) 0%,
-    var(--piggy-information-card-end) 100%
-  );
-  border: var(--piggy-card-border-width) solid
-    var(--piggy-information-card-border);
+  background: linear-gradient(135deg,
+      var(--piggy-information-card-start) 0%,
+      var(--piggy-information-card-end) 100%);
+  border: var(--piggy-card-border-width) solid var(--piggy-information-card-border);
   padding: 0.75rem;
 }
 
@@ -884,23 +918,21 @@ ol {
 |*     NAVIGATION MENU     *|
 \***************************/
 .piggy-navbar {
-  background: linear-gradient(
-    90deg,
-    var(--piggy-navbar-start) 0%,
-    var(--piggy-navbar-end) 100%
-  );
+  background: linear-gradient(90deg,
+      var(--piggy-navbar-start) 0%,
+      var(--piggy-navbar-end) 100%);
   vertical-align: middle;
 }
 
 .piggy-breadcrumb {
   color: var(--piggy-text-breadcrumb);
-  font-size: var(--piggy-font-size);
+  font-size: calc(1rem * var(--piggy-font-scale));
 }
 
 .piggy-breadcrumb:not(.no-hover):hover {
   color: var(--piggy-text-breadcrumb-hover);
   transition: color 0.2s ease;
-  font-size: var(--piggy-font-size);
+  font-size: calc(1rem * var(--piggy-font-scale));
 }
 
 /**********************\
@@ -925,7 +957,7 @@ ol {
   border-radius: 25px;
   background-color: var(--piggy-main);
   color: var(--piggy-text-main);
-  font-size: 16px;
+  font-size: calc(1rem * var(--piggy-font-scale));
   outline: none;
   transition:
     border-color 0.3s,
@@ -953,8 +985,8 @@ ol {
 }
 
 .search-icon-svg {
-  width: 20px;
-  height: 20px;
+  width: calc(1rem * var(--piggy-font-scale));
+  height: calc(1rem * var(--piggy-font-scale));
 }
 
 .search-icon::after {
@@ -985,7 +1017,8 @@ ol {
   position: fixed;
   top: 0;
   right: 0;
-  width: 0; /* Start closed */
+  width: 0;
+  /* Start closed */
   height: 100%;
   background-color: var(--piggy-menu);
   color: var(--piggy-menu-text);
@@ -1123,11 +1156,9 @@ ol {
 #meta-container {
   display: flex;
   align-items: center;
-  background: linear-gradient(
-    90deg,
-    var(--piggy-navbar-start) 0%,
-    var(--piggy-navbar-end) 100%
-  );
+  background: linear-gradient(90deg,
+      var(--piggy-navbar-start) 0%,
+      var(--piggy-navbar-end) 100%);
   border-top: 2px solid var(--piggy-card-start);
 }
 
@@ -1145,8 +1176,8 @@ ol {
 #level-container .snout-button {
   flex: 1;
   position: relative;
-  min-width: 110px;
-  max-width: 110px;
+  min-width: calc(4rem * var(--piggy-font-scale));
+  max-width: calc(8rem * var(--piggy-font-scale));
   white-space: nowrap;
   text-align: center;
 }
@@ -1186,11 +1217,11 @@ ol {
   border-color: transparent transparent var(--piggy-tooltip) transparent;
 }
 
-@media (max-width: 800px){
+@media (max-width: 800px) {
   .level-button-text {
     display: none;
   }
-  
+
   #level-container .snout-button {
     min-width: 48px;
     max-width: 48px;
@@ -1205,12 +1236,12 @@ ol {
   header {
     position: relative;
   }
-  
+
   #level-container {
     flex-wrap: wrap;
     gap: 5px;
   }
-  
+
   #level-container .snout-button {
     min-width: 48px;
     max-width: 48px;
@@ -1272,7 +1303,8 @@ ol {
   white-space: nowrap;
   box-shadow: 0px 8px 16px 0px var(--piggy-shadow-box);
   border-radius: 5px;
-  top: 100%; /* Position the dropdown below the button */
+  top: 100%;
+  /* Position the dropdown below the button */
   left: 0;
   z-index: 1000;
 
@@ -1377,7 +1409,7 @@ details p:nth-child(2) {
 
 .md-content h1,
 .md-content h1 code {
-  font-size: 2.0rem !important;
+  font-size: calc(2rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content h1 {
@@ -1387,7 +1419,7 @@ details p:nth-child(2) {
 
 .md-content h2,
 .md-content h2 code {
-  font-size: 1.75rem !important;
+  font-size: calc(1.75rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content h2 {
@@ -1397,7 +1429,7 @@ details p:nth-child(2) {
 
 .md-content h3,
 .md-content h3 code {
-  font-size: 1.35rem !important;
+  font-size: calc(1.35rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content h3 {
@@ -1407,7 +1439,7 @@ details p:nth-child(2) {
 
 .md-content h4,
 .md-content h4 code {
-  font-size: 1.15rem !important;
+  font-size: calc(1.15rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content h4 {
@@ -1417,7 +1449,7 @@ details p:nth-child(2) {
 
 .md-content h5,
 .md-content h5 code {
-  font-size: 1.05rem !important;
+  font-size: calc(1.05rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content h5 {
@@ -1427,7 +1459,7 @@ details p:nth-child(2) {
 
 .md-content h6,
 .md-content h6 code {
-  font-size: 1.00rem !important;
+  font-size: calc(1rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content h6 {
@@ -1436,21 +1468,21 @@ details p:nth-child(2) {
 }
 
 .md-content p {
-  font-size: 1rem !important;
+  font-size: calc(1rem * var(--piggy-font-scale)) !important;
   margin-bottom: 0.75rem;
   margin-top: 0.25rem;
 }
 
 .md-content ul {
-  font-size: 1rem !important;
+  font-size: calc(1rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content code,
 .md-content summary,
 .md-content table,
 .md-content .linenos {
-  font-size: 0.8rem !important;
-  line-height: 1rem;
+  font-size: calc(0.8rem * var(--piggy-font-scale)) !important;
+  line-height: calc(1rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content code:not(.md-code__content) {
@@ -1495,7 +1527,7 @@ details p:nth-child(2) {
 .md-content summary {
   padding-top: 0.6rem !important;
   padding-bottom: 0.6rem !important;
-  font-size: 1rem !important;
+  font-size: calc(1rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content blockquote {
@@ -1522,13 +1554,13 @@ details p:nth-child(2) {
 }
 
 .md-content .tabbed-labels a {
-  font-size: 0.9rem !important;
+  font-size: calc(0.9rem * var(--piggy-font-scale)) !important;
   color: var(--piggy-text-main) !important;
 }
 
 .md-content .MathJax {
   text-align: left !important;
-  font-size: 1rem !important;
+  font-size: calc(1rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content .tabbed-set {
@@ -1543,20 +1575,20 @@ details p:nth-child(2) {
 
 details ol li,
 .admonition ol li {
-  font-size: 1rem !important;
+  font-size: calc(1rem * var(--piggy-font-scale)) !important;
   list-style: decimal !important;
 }
 
 details ul li,
 .admonition ul li {
-  font-size: 1rem !important;
+  font-size: calc(1rem * var(--piggy-font-scale)) !important;
   list-style: disc !important;
 }
 
 .md-content .arithmatex,
 .md-content .MJX-TEX {
   font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif !important;
-  font-size: 1rem;
+  font-size: calc(1rem * var(--piggy-font-scale)) !important;
 }
 
 .md-code__content span {
@@ -1565,11 +1597,13 @@ details ul li,
   overflow: hidden !important;
   text-wrap: wrap !important;
   word-wrap: break-word !important;
-  font-size: 0.85rem !important;
+  padding-top: calc(0.25rem * var(--piggy-font-scale)) !important;
+  padding-bottom: calc(0.25rem * var(--piggy-font-scale)) !important;
+  font-size: calc(0.85rem * var(--piggy-font-scale)) !important;
 }
 
 code.md-code__content {
-    background-color: #0e0e0e !important;
+  background-color: #0e0e0e !important;
 }
 
 .md-clipboard {
@@ -1621,32 +1655,29 @@ code.md-code__content {
 }
 
 #piggy-logo-icon {
-  display: inline; 
-  width: 32px; 
-  bottom: 5px; 
+  display: inline;
+  width: calc(2rem * var(--piggy-font-scale));
+  bottom: calc(0.35rem * var(--piggy-font-scale));
   position: relative;
 }
 
 #piggy-logo-text {
   font-family: "Cherry Bomb One", sans-serif;
   font-weight: 700;
-  font-size: 1.85rem;
+  font-size: calc(1.85rem * var(--piggy-font-scale));
   color: var(--piggy-logo);
   background: var(--piggy-logo-gradient);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   letter-spacing: 0.65px;
-  filter: drop-shadow(1px 0 0 var(--piggy-logo-border))
-    drop-shadow(-1px 0 0 var(--piggy-logo-border))
-    drop-shadow(0 1px 0 var(--piggy-logo-border))
-    drop-shadow(0 -1px 0 var(--piggy-logo-border));
+  filter: drop-shadow(1px 0 0 var(--piggy-logo-border)) drop-shadow(-1px 0 0 var(--piggy-logo-border)) drop-shadow(0 1px 0 var(--piggy-logo-border)) drop-shadow(0 -1px 0 var(--piggy-logo-border));
   text-shadow: none;
   transition: 0.2s;
 }
 
 #piggy-index-icon {
-  display: inline; 
-  width: 64px; 
+  display: inline;
+  width: 64px;
   bottom: 8px;
   position: relative;
 }
@@ -1655,15 +1686,19 @@ code.md-code__content {
   0% {
     transform: scale(1.0) rotate(0deg);
   }
+
   25% {
     transform: scale(1.1) rotate(3deg);
   }
+
   50% {
     transform: scale(1.0) rotate(0deg);
   }
+
   75% {
     transform: scale(1.1) rotate(-3deg);
   }
+
   100% {
     transform: scale(1.0) rotate(0deg);
   }

--- a/piggy/static/css/styles.css
+++ b/piggy/static/css/styles.css
@@ -96,10 +96,6 @@
   font-display: swap;
 }
 
-.md-code__content {
-  font-family: "Cascadia Code PL", monospace !important;
-}
-
 /***********************\
 |*     FONT THEMES     *|
 \***********************/
@@ -186,6 +182,49 @@
 [data-font-theme="century-gothic"] *:not(code *, code, .MathJax *) {
   font-family: "Century Gothic", "Lucida Sans Unicode", sans-serif;
   letter-spacing: 0px;
+}
+
+/***************************\
+|*  MONOSPACE FONT THEMES  *|
+\***************************/
+[data-mono-theme="default"] code {
+  font-family: "Cascadia Code PL", monospace !important;
+}
+
+[data-mono-theme="fira-code"] code {
+  font-family: "Fira Code", monospace !important;
+}
+
+[data-mono-theme="roboto-mono"] code {
+  font-family: "Roboto Mono", monospace !important;
+}
+
+[data-mono-theme="jetbrains-mono"] code {
+  font-family: "JetBrains Mono", monospace !important;
+}
+
+[data-mono-theme="dm-mono"] code {
+  font-family: "DM Mono", monospace !important;
+  font-weight: 400;
+  font-style: normal;
+}
+
+[data-mono-theme="ubuntu-mono"] code {
+  font-family: "Ubuntu Mono", monospace !important;
+  font-weight: 400;
+  font-style: normal;
+}
+
+[data-mono-theme="kode-mono"] code {
+  font-family: "Kode Mono", monospace !important;
+}
+
+[data-mono-theme="lucida"] code {
+  font-family: "Lucida Console", monospace !important;
+}
+
+[data-mono-theme="courier"] code {
+  font-family: "Courier New", monospace !important;
 }
 
 /****************************\

--- a/piggy/static/css/styles.css
+++ b/piggy/static/css/styles.css
@@ -1,7 +1,7 @@
 :root {
   --piggy-font-scale: 1;
 
-  font-size: 16px;
+  font-size: 17px;
 
   font-family: "Noto Sans", sans-serif;
   font-optical-sizing: auto;
@@ -192,7 +192,7 @@
 |*     FONT SIZE THEMES     *|
 \****************************/
 :root[data-font-size="xx-small"] {
-  --piggy-font-scale: 0.75;
+  --piggy-font-scale: 0.7;
 }
 
 :root[data-font-size="x-small"] {
@@ -200,23 +200,27 @@
 }
 
 :root[data-font-size="small"] {
-  --piggy-font-scale: 0.9;
+  --piggy-font-scale: 1.0;
 }
 
-:root[data-font-size="normal"] {
-  --piggy-font-scale: 1;
+:root[data-font-size="default"] {
+  --piggy-font-scale: 1.075;
 }
 
 :root[data-font-size="large"] {
-  --piggy-font-scale: 1.25;
+  --piggy-font-scale: 1.2;
 }
 
 :root[data-font-size="x-large"] {
-  --piggy-font-scale: 1.5;
+  --piggy-font-scale: 1.35;
 }
 
 :root[data-font-size="xx-large"] {
-  --piggy-font-scale: 2.0;
+  --piggy-font-scale: 1.5;
+}
+
+:root[data-font-size="xxx-large"] {
+  --piggy-font-scale: 1.85;
 }
 
 /*****************************\
@@ -1347,7 +1351,7 @@ ol {
 \******************************/
 
 .md-content {
-  padding: 0.0rem 0.35rem !important;
+  padding: 0.0rem 0.1rem !important;
 }
 
 .md-container a {
@@ -1479,10 +1483,18 @@ details p:nth-child(2) {
 
 .md-content code,
 .md-content summary,
-.md-content table,
 .md-content .linenos {
-  font-size: calc(0.8rem * var(--piggy-font-scale)) !important;
+  font-size: calc(0.875rem * var(--piggy-font-scale)) !important;
   line-height: calc(1rem * var(--piggy-font-scale)) !important;
+}
+
+.md-content table {
+  font-size: calc(0.9rem * var(--piggy-font-scale)) !important;
+  line-height: calc(1.1rem * var(--piggy-font-scale)) !important;
+}
+
+.md-content table td {
+  padding: calc(0.65rem * var(--piggy-font-scale)) !important;
 }
 
 .md-content code:not(.md-code__content) {

--- a/piggy/static/css/themes/classic.css
+++ b/piggy/static/css/themes/classic.css
@@ -111,10 +111,6 @@ preview_style: background: linear-gradient(90deg, #d6c8d5, #ffffff); color: #000
   border-radius: 0.5rem;
 }
 
-[data-theme="classic"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
-}
-
 [data-theme="classic"] .md-content code:not(.md-code__content) {
   background-color: #d1d1d1;
   color: var(--piggy-dark);

--- a/piggy/static/css/themes/desert.css
+++ b/piggy/static/css/themes/desert.css
@@ -35,11 +35,11 @@ preview_style: background: linear-gradient(90deg, #f4e7d3, #a67c52); color: #1d1
   --piggy-assignment-card-start: rgba(168, 121, 85, 0.7);
   --piggy-assignment-card-end: rgba(196, 119, 60, 0.3);
   --piggy-assignment-card-border: #b37a4e;
-  --piggy-assignment-overlay: rgba(179, 121,  78, 0.85);
+  --piggy-assignment-overlay: rgba(179, 121, 78, 0.85);
   --piggy-assignment-accent: #b37a4e;
-  --piggy-assignment-shadow-glow: rgba(179, 121,  78, 0.5);
+  --piggy-assignment-shadow-glow: rgba(179, 121, 78, 0.5);
 
-    /* Information cards */
+  /* Information cards */
   --piggy-information-card-start: rgba(168, 85, 89, 0.7);
   --piggy-information-card-end: rgba(196, 60, 78, 0.3);
   --piggy-information-card-border: #b34e4e;
@@ -125,10 +125,6 @@ preview_style: background: linear-gradient(90deg, #f4e7d3, #a67c52); color: #1d1
   border: 1px solid #5f4b32;
   border-radius: 0.5rem;
   background-color: #e8d4b0;
-}
-
-[data-theme="desert"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
 }
 
 [data-theme="desert"] .md-content code:not(.md-code__content) {

--- a/piggy/static/css/themes/golden.css
+++ b/piggy/static/css/themes/golden.css
@@ -100,10 +100,6 @@ preview_style: background: linear-gradient(90deg, #0b0b0e, #6d5520); color: #ffd
 /******************************\
 |*     MARKDOWN OVERRIDES     *|
 \******************************/
-[data-theme="golden"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
-}
-
 [data-theme="golden"] .md-content code:not(.md-code__content) {
   background-color: #1e1e26;
   color: #ffe7a0;

--- a/piggy/static/css/themes/high-contrast.css
+++ b/piggy/static/css/themes/high-contrast.css
@@ -176,19 +176,13 @@ preview_style: background-color: #000000; color: #ffffff; border: 1px solid #fff
   border-bottom: 1px solid white;
 }
 
-[data-theme="high-contrast"]
-  #language-container
-  .language-dropdown
-  a:last-child {
+[data-theme="high-contrast"] #language-container .language-dropdown a:last-child {
   border-bottom: none;
   border-bottom-left-radius: 0px;
   border-bottom-right-radius: 0px;
 }
 
-[data-theme="high-contrast"]
-  #language-container
-  .language-dropdown
-  a:first-child {
+[data-theme="high-contrast"] #language-container .language-dropdown a:first-child {
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
 }
@@ -196,10 +190,6 @@ preview_style: background-color: #000000; color: #ffffff; border: 1px solid #fff
 /******************************\
 |*     MARKDOWN OVERRIDES     *|
 \******************************/
-[data-theme="high-contrast"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
-}
-
 [data-theme="high-contrast"] .md-content code:not(.md-code__content) {
   background-color: black;
   color: white;
@@ -314,26 +304,16 @@ preview_style: background-color: #000000; color: #ffffff; border: 1px solid #fff
   border-color: #00ffff !important;
 }
 
-[data-theme="high-contrast"]
-  .md-content
-  :is(.note, .abstract, .info, .tip)
-  summary {
+[data-theme="high-contrast"] .md-content :is(.note, .abstract, .info, .tip) summary {
   background-color: #00ffff20 !important;
 }
 
-[data-theme="high-contrast"]
-  .md-content
-  :is(.note, .abstract, .info, .tip)
-  summary::after {
+[data-theme="high-contrast"] .md-content :is(.note, .abstract, .info, .tip) summary::after {
   color: #00ffff !important;
 }
 
-[data-theme="high-contrast"]
-  .md-content
-  :is(.note, .abstract, .info, .tip)
-  :is(summary, .admonition-title)::before {
-  filter: brightness(0) saturate(100%) invert(94%) sepia(77%) saturate(7497%)
-    hue-rotate(102deg) brightness(109%) contrast(101%);
+[data-theme="high-contrast"] .md-content :is(.note, .abstract, .info, .tip) :is(summary, .admonition-title)::before {
+  filter: brightness(0) saturate(100%) invert(94%) sepia(77%) saturate(7497%) hue-rotate(102deg) brightness(109%) contrast(101%);
 }
 
 /* SUCCESS, QUESTION [GREEN] */
@@ -345,19 +325,12 @@ preview_style: background-color: #000000; color: #ffffff; border: 1px solid #fff
   background-color: #00ff0020 !important;
 }
 
-[data-theme="high-contrast"]
-  .md-content
-  :is(.success, .question)
-  summary::after {
+[data-theme="high-contrast"] .md-content :is(.success, .question) summary::after {
   color: #00ff00 !important;
 }
 
-[data-theme="high-contrast"]
-  .md-content
-  :is(.success, .question)
-  :is(summary, .admonition-title)::before {
-  filter: brightness(0) saturate(100%) invert(72%) sepia(48%) saturate(7500%)
-    hue-rotate(84deg) brightness(127%) contrast(115%);
+[data-theme="high-contrast"] .md-content :is(.success, .question) :is(summary, .admonition-title)::before {
+  filter: brightness(0) saturate(100%) invert(72%) sepia(48%) saturate(7500%) hue-rotate(84deg) brightness(127%) contrast(115%);
 }
 
 /* WARNING, FAILURE [ORANGE] */
@@ -369,19 +342,12 @@ preview_style: background-color: #000000; color: #ffffff; border: 1px solid #fff
   background-color: #ff5b0020 !important;
 }
 
-[data-theme="high-contrast"]
-  .md-content
-  :is(.warning, .failure)
-  summary::after {
+[data-theme="high-contrast"] .md-content :is(.warning, .failure) summary::after {
   color: #ff5b00 !important;
 }
 
-[data-theme="high-contrast"]
-  .md-content
-  :is(.warning, .failure)
-  :is(summary, .admonition-title)::before {
-  filter: brightness(0) saturate(100%) invert(38%) sepia(49%) saturate(3030%)
-    hue-rotate(1deg) brightness(103%) contrast(106%);
+[data-theme="high-contrast"] .md-content :is(.warning, .failure) :is(summary, .admonition-title)::before {
+  filter: brightness(0) saturate(100%) invert(38%) sepia(49%) saturate(3030%) hue-rotate(1deg) brightness(103%) contrast(106%);
 }
 
 /* DANGER, BUG [RED] */
@@ -398,12 +364,8 @@ preview_style: background-color: #000000; color: #ffffff; border: 1px solid #fff
   color: #ff0000 !important;
 }
 
-[data-theme="high-contrast"]
-  .md-content
-  :is(.danger, .bug)
-  :is(summary, .admonition-title)::before {
-  filter: brightness(0) saturate(100%) invert(16%) sepia(90%) saturate(6855%)
-    hue-rotate(6deg) brightness(101%) contrast(124%);
+[data-theme="high-contrast"] .md-content :is(.danger, .bug) :is(summary, .admonition-title)::before {
+  filter: brightness(0) saturate(100%) invert(16%) sepia(90%) saturate(6855%) hue-rotate(6deg) brightness(101%) contrast(124%);
 }
 
 /* EXAMPLE [MAGENTA] */
@@ -419,12 +381,8 @@ preview_style: background-color: #000000; color: #ffffff; border: 1px solid #fff
   color: #ff00ff !important;
 }
 
-[data-theme="high-contrast"]
-  .md-content
-  :is(.example)
-  :is(summary, .admonition-title)::before {
-  filter: brightness(0) saturate(100%) invert(17%) sepia(75%) saturate(5424%)
-    hue-rotate(294deg) brightness(116%) contrast(122%);
+[data-theme="high-contrast"] .md-content :is(.example) :is(summary, .admonition-title)::before {
+  filter: brightness(0) saturate(100%) invert(17%) sepia(75%) saturate(5424%) hue-rotate(294deg) brightness(116%) contrast(122%);
 }
 
 /* QUOTE [WHITE] */
@@ -440,9 +398,6 @@ preview_style: background-color: #000000; color: #ffffff; border: 1px solid #fff
   color: #ffffff !important;
 }
 
-[data-theme="high-contrast"]
-  .md-content
-  :is(.quote)
-  :is(summary, .admonition-title)::before {
+[data-theme="high-contrast"] .md-content :is(.quote) :is(summary, .admonition-title)::before {
   filter: grayscale() brightness(2);
 }

--- a/piggy/static/css/themes/light.css
+++ b/piggy/static/css/themes/light.css
@@ -33,7 +33,7 @@ preview_style: background: linear-gradient(90deg, #ffffff, rgb(240, 240, 240)); 
   --piggy-assignment-accent: #f57c00;
   --piggy-assignment-shadow-glow: rgba(245, 124, 0, 0.5);
 
-    /* Information cards */
+  /* Information cards */
   --piggy-information-card-start: rgba(138, 203, 255, 0.5);
   --piggy-information-card-end: rgba(63, 139, 214, 0.5);
   --piggy-information-card-border: rgba(64, 129, 170, 0.75);
@@ -112,10 +112,6 @@ preview_style: background: linear-gradient(90deg, #ffffff, rgb(240, 240, 240)); 
 [data-theme="light"] .md-content {
   border: 1px solid #414141aa;
   border-radius: 0.5rem;
-}
-
-[data-theme="light"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
 }
 
 [data-theme="light"] .md-content code:not(.md-code__content) {

--- a/piggy/static/css/themes/matrix.css
+++ b/piggy/static/css/themes/matrix.css
@@ -43,7 +43,7 @@ preview_style: background: linear-gradient(90deg, #000000, #004400); color: #00f
 
   --piggy-card-border-width: 1px;
 
-    /* Information cards */
+  /* Information cards */
   --piggy-information-card-start: rgba(0, 98, 179, 0.384);
   --piggy-information-card-end: rgba(0, 100, 200, 0.35);
   --piggy-information-card-border: rgba(0, 156, 255, 0.5);
@@ -155,9 +155,8 @@ preview_style: background: linear-gradient(90deg, #000000, #004400); color: #00f
   box-shadow: var(--piggy-assignment-shadow-glow) !important;
 }
 
-[data-theme="matrix"] 
-  .card-assignment .description-container,
-  .card-assignment .card-title {
+[data-theme="matrix"] .card-assignment .description-container,
+.card-assignment .card-title {
   color: var(--piggy-assignment-text) !important;
 }
 
@@ -168,13 +167,9 @@ preview_style: background: linear-gradient(90deg, #000000, #004400); color: #00f
 /******************************\
 |*     MARKDOWN OVERRIDES     *|
 \******************************/
-
-[data-theme="matrix"] .md-content, .md-code__content {
+[data-theme="matrix"] .md-content,
+.md-code__content {
   border-radius: 0.25rem !important;
-}
-
-[data-theme="matrix"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
 }
 
 [data-theme="matrix"] .md-content .md-code__content {

--- a/piggy/static/css/themes/ocean.css
+++ b/piggy/static/css/themes/ocean.css
@@ -31,12 +31,12 @@ preview_style: background: linear-gradient(90deg, #002b36, #336b87); color: #a7d
   --piggy-card-border: #88c0d0;
   --piggy-text-card: var(--piggy-text-light);
 
-  --piggy-assignment-card-start: rgba(255,127,80,0.4);
-  --piggy-assignment-card-end: rgba(255,99,71,0.2);
+  --piggy-assignment-card-start: rgba(255, 127, 80, 0.4);
+  --piggy-assignment-card-end: rgba(255, 99, 71, 0.2);
   --piggy-assignment-card-border: #FF6347;
-  --piggy-assignment-overlay: rgba(255,99,71,0.8);
+  --piggy-assignment-overlay: rgba(255, 99, 71, 0.8);
   --piggy-assignment-accent: #FF6347;
-  --piggy-assignment-shadow-glow: rgba(255,99,71,0.5);
+  --piggy-assignment-shadow-glow: rgba(255, 99, 71, 0.5);
 
   --piggy-card-border-width: 1px;
 
@@ -115,11 +115,6 @@ preview_style: background: linear-gradient(90deg, #002b36, #336b87); color: #a7d
 /******************************\
 |*     MARKDOWN OVERRIDES     *|
 \******************************/
-
-[data-theme="ocean"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
-}
-
 [data-theme="ocean"] .md-content code:not(.md-code__content) {
   background-color: #001219;
   color: #d8f3f8;

--- a/piggy/static/css/themes/piggy-dark.css
+++ b/piggy/static/css/themes/piggy-dark.css
@@ -25,13 +25,13 @@ preview_style: background: linear-gradient(90deg, #1f1518, #3d2a30); color: #ece
   --piggy-card-border: #a06672;
   --piggy-text-card: var(--piggy-dark);
 
-  --piggy-assignment-card-start: rgba(192,133,142,0.3);
-  --piggy-assignment-card-end: rgba(160,100,114,0.3);
+  --piggy-assignment-card-start: rgba(192, 133, 142, 0.3);
+  --piggy-assignment-card-end: rgba(160, 100, 114, 0.3);
   --piggy-assignment-card-border: #a06472;
-  --piggy-assignment-overlay: rgba(160,100,114,0.85);
+  --piggy-assignment-overlay: rgba(160, 100, 114, 0.85);
   --piggy-assignment-accent: #a06472;
-  --piggy-assignment-shadow-glow: rgba(160,100,114,0.5);
-  
+  --piggy-assignment-shadow-glow: rgba(160, 100, 114, 0.5);
+
   /* Information cards */
   --piggy-information-card-start: rgba(0, 98, 179, 0.384);
   --piggy-information-card-end: rgba(0, 100, 200, 0.35);
@@ -109,10 +109,6 @@ preview_style: background: linear-gradient(90deg, #1f1518, #3d2a30); color: #ece
 [data-theme="piggy-dark"] .md-content {
   border: 1px solid #85607caa;
   border-radius: 0.5rem;
-}
-
-[data-theme="piggy-dark"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
 }
 
 [data-theme="piggy-dark"] .md-content code:not(.md-code__content) {

--- a/piggy/static/css/themes/piggy.css
+++ b/piggy/static/css/themes/piggy.css
@@ -25,7 +25,7 @@ preview_style: background: linear-gradient(90deg, #ffe6e9, #ff99cc); color: rgb(
   --piggy-card-end: rgba(255, 220, 229, 1);
   --piggy-card-border: #ff99cc;
   --piggy-text-card: var(--piggy-dark);
-  
+
   /* Assignment cards */
   --piggy-assignment-card-start: rgba(255, 137, 220, 0.5);
   --piggy-assignment-card-end: rgba(255, 170, 230, 0.5);
@@ -34,7 +34,7 @@ preview_style: background: linear-gradient(90deg, #ffe6e9, #ff99cc); color: rgb(
   --piggy-assignment-accent: #ff4d6d;
   --piggy-assignment-shadow-glow: rgba(255, 77, 109, 0.5);
 
-    /* Information cards */
+  /* Information cards */
   --piggy-information-card-start: rgba(138, 203, 255, 0.5);
   --piggy-information-card-end: rgba(63, 139, 214, 0.5);
   --piggy-information-card-border: rgba(64, 129, 170, 0.75);
@@ -112,10 +112,6 @@ preview_style: background: linear-gradient(90deg, #ffe6e9, #ff99cc); color: rgb(
 [data-theme="piggy"] .md-content {
   border: 1px solid #573e51aa;
   border-radius: 0.5rem;
-}
-
-[data-theme="piggy"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
 }
 
 [data-theme="piggy"] .md-content code:not(.md-code__content) {

--- a/piggy/static/css/themes/space.css
+++ b/piggy/static/css/themes/space.css
@@ -111,11 +111,6 @@ preview_style: background-color: #0b0c10; color: #66fcf1; text-shadow: none;
 /******************************\
 |*     MARKDOWN OVERRIDES     *|
 \******************************/
-
-[data-theme="space"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
-}
-
 [data-theme="space"] .md-content code:not(.md-code__content) {
   background-color: #0f0f0f;
   color: #66fcf1;

--- a/piggy/static/css/themes/synthwave.css
+++ b/piggy/static/css/themes/synthwave.css
@@ -151,6 +151,7 @@ preview_style: background: linear-gradient(90deg, rgba(120, 0, 180, 1.0), #FF572
   from {
     background-position: 0 0;
   }
+
   to {
     background-position: 0 200px;
   }
@@ -158,18 +159,14 @@ preview_style: background: linear-gradient(90deg, rgba(120, 0, 180, 1.0), #FF572
 
 [data-theme="synthwave"] .background-overlay {
   height: 200%;
-  background-image: linear-gradient(
-      to right,
+  background-image: linear-gradient(to right,
       transparent 0%,
       transparent 98%,
-      var(--grid-line-color) 99%
-    ),
-    linear-gradient(
-      to bottom,
+      var(--grid-line-color) 99%),
+    linear-gradient(to bottom,
       transparent 0%,
       transparent 98%,
-      var(--grid-line-color) 99%
-    );
+      var(--grid-line-color) 99%);
   background-size: 2.5rem 2.5rem;
   transform-origin: top center;
   transform: translateY(2%) perspective(40rem) rotateX(77deg);
@@ -189,18 +186,22 @@ preview_style: background: linear-gradient(90deg, rgba(120, 0, 180, 1.0), #FF572
     box-shadow: 0px 0px 15px 0 #ff00a6;
     border-color: #ff00a6;
   }
+
   25% {
     box-shadow: 0px 0px 15px 0 #ff9500;
     border-color: #ff9500;
   }
+
   50% {
     box-shadow: 0px 0px 15px 0 #00ff33;
     border-color: #00ff33;
   }
+
   75% {
     box-shadow: 0px 0px 15px 0 #009dff;
     border-color: #009dff;
   }
+
   100% {
     box-shadow: 0px 0px 15px 0 #ff00a6;
     border-color: #ff00a6;
@@ -209,8 +210,7 @@ preview_style: background: linear-gradient(90deg, rgba(120, 0, 180, 1.0), #FF572
 
 [data-theme="synthwave"] .card-container:hover {
   border-color: #ff00ff;
-  transform: perspective(1000px) rotateX(-1deg) rotateY(3deg) rotateZ(1deg)
-    scale(98%);
+  transform: perspective(1000px) rotateX(-1deg) rotateY(3deg) rotateZ(1deg) scale(98%);
   box-shadow: 0px 0px 15px 0 #ff00a6;
   animation: boxShadowScroll 2s alternate infinite;
   animation-timing-function: linear;
@@ -228,10 +228,6 @@ preview_style: background: linear-gradient(90deg, rgba(120, 0, 180, 1.0), #FF572
 /******************************\
 |*     MARKDOWN OVERRIDES     *|
 \******************************/
-[data-theme="synthwave"] .md-content .admonition-title {
-  font-size: 0.8rem !important;
-}
-
 [data-theme="synthwave"] .md-content {
   border: 1px solid #cc00ffaa;
   border-radius: 0.5rem;

--- a/piggy/static/js/main.js
+++ b/piggy/static/js/main.js
@@ -1,39 +1,64 @@
 document.addEventListener("DOMContentLoaded", () => {
-  // Get elements for the settings menu
   const settingsMenu = document.getElementById("settings-menu");
   const settingsButton = document.getElementById("settings-button");
   const closeButton = document.querySelector("#settings-menu .close-button");
 
-  // Get custom select elements for theme and font
   const themeSelect = document.getElementById("theme-select");
-  const themeSelected = themeSelect.querySelector(".selected");
   const fontSelect = document.getElementById("font-select");
-  const fontSelected = fontSelect
-    ? fontSelect.querySelector(".selected")
-    : null;
+  const fontSizeSelect = document.getElementById("font-size-select");
 
-  // --- Helper Functions ---
+  const THEME_STORAGE_KEY = "theme";
+  const FONT_STORAGE_KEY = "fontTheme";
+  const FONT_SIZE_STORAGE_KEY = "fontSize";
+  const DEFAULT_FONT_THEME = "default";
+  const DEFAULT_FONT_SIZE = "default";
+
   function closeAllCustomSelects(except = null) {
     document.querySelectorAll(".custom-select").forEach((select) => {
       if (select !== except) {
-        select.classList.remove("open");
-        const optionsContainer = select.querySelector(".options-container");
-        if (optionsContainer) {
-          optionsContainer.style.maxHeight = "";
-        }
+        closeCustomSelect(select);
       }
     });
   }
 
-  // Dynamically calculate available space and set max-height on the options container
-  function updateOptionsMaxHeight(select) {
-    const optionsContainer = select.querySelector(".options-container");
-    const rect = optionsContainer.getBoundingClientRect();
-    const availableHeight = window.innerHeight - rect.top - 10; // 10px margin
-    optionsContainer.style.maxHeight = availableHeight + "px";
+  function openCustomSelect(select) {
+    if (!select) return;
+    select.classList.add("open");
+    updateOptionsMaxHeight(select);
   }
 
-  // Smooth page transition
+  function closeCustomSelect(select) {
+    if (!select) return;
+    select.classList.remove("open");
+
+    const optionsContainer = select.querySelector(".options-container");
+    if (optionsContainer) {
+      optionsContainer.style.maxHeight = "";
+    }
+  }
+
+  function toggleCustomSelect(select) {
+    if (!select) return;
+
+    const isOpen = select.classList.contains("open");
+    closeAllCustomSelects(select);
+
+    if (isOpen) {
+      closeCustomSelect(select);
+    } else {
+      openCustomSelect(select);
+    }
+  }
+
+  function updateOptionsMaxHeight(select) {
+    const optionsContainer = select.querySelector(".options-container");
+    if (!optionsContainer) return;
+
+    const rect = optionsContainer.getBoundingClientRect();
+    const availableHeight = window.innerHeight - rect.top - 10;
+    optionsContainer.style.maxHeight = `${availableHeight}px`;
+  }
+
   function pageTransition() {
     document.body.classList.add("transition");
     setTimeout(() => {
@@ -41,7 +66,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 1000);
   }
 
-  // Stop all background animations
   function stopAllAnimations() {
     stopMatrixAnimation();
     stopOceanShaderAnimation();
@@ -50,30 +74,85 @@ document.addEventListener("DOMContentLoaded", () => {
     stopGoldenShaderAnimation();
   }
 
-  // --- Background Animations ---
-  // currentTheme is set in on-load.js; fallback to system preference if not set
-  const currentTheme = localStorage.getItem("theme") || systemPreferredTheme;
-  switch (currentTheme) {
-    case "matrix":
-      startMatrixAnimation();
-      break;
-    case "ocean":
-      startOceanShaderAnimation();
-      break;
-    case "desert":
-      startDesertShaderAnimation();
-      break;
-    case "golden":
-      startGoldenShaderAnimation();
-      break;
-    case "space":
-      startSpaceAnimation();
-      break;
-    default:
-      stopAllAnimations();
+  function applyTheme(theme) {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+    document.documentElement.setAttribute("data-theme", theme);
+
+    pageTransition();
+    stopAllAnimations();
+
+    switch (theme) {
+      case "matrix":
+        startMatrixAnimation();
+        break;
+      case "ocean":
+        startOceanShaderAnimation();
+        break;
+      case "desert":
+        startDesertShaderAnimation();
+        break;
+      case "golden":
+        startGoldenShaderAnimation();
+        break;
+      case "space":
+        startSpaceAnimation();
+        break;
+    }
   }
 
-  // --- Settings Menu Functions ---
+  function applyFontTheme(fontTheme) {
+    localStorage.setItem(FONT_STORAGE_KEY, fontTheme);
+    document.documentElement.setAttribute("data-font-theme", fontTheme);
+  }
+
+  function applyFontSize(fontSize) {
+    localStorage.setItem(FONT_SIZE_STORAGE_KEY, fontSize);
+    document.documentElement.setAttribute("data-font-size", fontSize);
+  }
+
+  function initializeCustomSelect({
+    select,
+    storageKey,
+    defaultValue,
+    onChange,
+  }) {
+    if (!select) return;
+
+    const selected = select.querySelector(".selected");
+    const options = select.querySelectorAll(".option");
+
+    if (!selected || options.length === 0) return;
+
+    const savedValue = localStorage.getItem(storageKey) || defaultValue;
+    const matchingOption = select.querySelector(
+      `.option[data-value="${savedValue}"]`,
+    );
+
+    if (matchingOption) {
+      selected.textContent = matchingOption.textContent;
+      selected.setAttribute("data-value", savedValue);
+    }
+
+    selected.addEventListener("click", (event) => {
+      toggleCustomSelect(select);
+      event.stopPropagation();
+    });
+
+    options.forEach((option) => {
+      option.addEventListener("click", (event) => {
+        const value = option.getAttribute("data-value");
+
+        selected.textContent = option.textContent;
+        selected.setAttribute("data-value", value);
+
+        onChange(value);
+        closeCustomSelect(select);
+
+        event.stopPropagation();
+      });
+    });
+  }
+
   function openSettingsMenu() {
     settingsMenu.classList.add("open");
   }
@@ -82,119 +161,50 @@ document.addEventListener("DOMContentLoaded", () => {
     settingsMenu.classList.remove("open");
   }
 
-  // --- Initialize Theme Custom Select ---
-  const matchingThemeOption = themeSelect.querySelector(
-    `.option[data-value="${currentTheme}"]`,
-  );
-  if (matchingThemeOption) {
-    themeSelected.textContent = matchingThemeOption.textContent;
-    themeSelected.setAttribute("data-value", currentTheme);
-  }
+  const currentTheme = localStorage.getItem(THEME_STORAGE_KEY) || systemPreferredTheme;
+  applyTheme(currentTheme);
 
-  // Toggle theme dropdown when clicking its selected area
-  themeSelected.addEventListener("click", (e) => {
-    closeAllCustomSelects(themeSelect);
-    themeSelect.classList.toggle("open");
-    if (themeSelect.classList.contains("open")) {
-      updateOptionsMaxHeight(themeSelect);
-    }
-    e.stopPropagation();
+  initializeCustomSelect({
+    select: themeSelect,
+    storageKey: THEME_STORAGE_KEY,
+    defaultValue: currentTheme,
+    onChange: applyTheme,
   });
 
-  // Attach click event listeners to each theme option
-  themeSelect.querySelectorAll(".option").forEach((option) => {
-    option.addEventListener("click", function (e) {
-      const selectedTheme = this.getAttribute("data-value");
-
-      themeSelected.textContent = this.textContent;
-      themeSelected.setAttribute("data-value", selectedTheme);
-
-      // save theme and apply
-      localStorage.setItem("theme", selectedTheme);
-      document.documentElement.setAttribute("data-theme", selectedTheme);
-
-      pageTransition();
-      stopAllAnimations();
-      switch (selectedTheme) {
-        case "matrix":
-          startMatrixAnimation();
-          break;
-        case "ocean":
-          startOceanShaderAnimation();
-          break;
-        case "desert":
-          startDesertShaderAnimation();
-          break;
-        case "golden":
-          startGoldenShaderAnimation();
-          break;
-        case "space":
-          startSpaceAnimation();
-          break;
-        default:
-          break;
-      }
-
-      // Close dropdown after selection
-      themeSelect.classList.remove("open");
-
-      const optionsContainer = themeSelect.querySelector(".options-container");
-      optionsContainer.style.maxHeight = "";
-
-      e.stopPropagation();
-    });
+  initializeCustomSelect({
+    select: fontSelect,
+    storageKey: FONT_STORAGE_KEY,
+    defaultValue: DEFAULT_FONT_THEME,
+    onChange: applyFontTheme,
   });
 
-  // --- Initialize Font Custom Select ---
-  if (fontSelect && fontSelected) {
-    const savedFontTheme = localStorage.getItem("fontTheme") || "default";
-    const matchingFontOption = fontSelect.querySelector(
-      `.option[data-value="${savedFontTheme}"]`,
-    );
-    if (matchingFontOption) {
-      fontSelected.textContent = matchingFontOption.textContent;
-      fontSelected.setAttribute("data-value", savedFontTheme);
-    }
+  initializeCustomSelect({
+    select: fontSizeSelect,
+    storageKey: FONT_SIZE_STORAGE_KEY,
+    defaultValue: DEFAULT_FONT_SIZE,
+    onChange: applyFontSize,
+  });
 
-    // Toggle font dropdown on click
-    fontSelected.addEventListener("click", (e) => {
-      closeAllCustomSelects(fontSelect);
-      fontSelect.classList.toggle("open");
-      if (fontSelect.classList.contains("open")) {
-        updateOptionsMaxHeight(fontSelect);
-      }
-      e.stopPropagation();
-    });
-
-    // Attach event listeners for each font option
-    fontSelect.querySelectorAll(".option").forEach((option) => {
-      option.addEventListener("click", function (e) {
-        const selectedFont = this.getAttribute("data-value");
-        fontSelected.textContent = this.textContent;
-        fontSelected.setAttribute("data-value", selectedFont);
-        localStorage.setItem("fontTheme", selectedFont);
-        document.documentElement.setAttribute("data-font-theme", selectedFont);
-        fontSelect.classList.remove("open");
-        e.stopPropagation();
-      });
-    });
-  }
-
-  // --- Global Listeners ---
   document.addEventListener("click", () => {
     closeAllCustomSelects();
   });
 
-  // Settings menu event listeners
-  settingsButton.addEventListener("click", openSettingsMenu);
-  closeButton.addEventListener("click", closeSettingsMenu);
-  window.addEventListener("click", function (event) {
+  settingsButton?.addEventListener("click", openSettingsMenu);
+  closeButton?.addEventListener("click", closeSettingsMenu);
+
+  window.addEventListener("click", (event) => {
     if (
-      settingsMenu.classList.contains("open") &&
+      settingsMenu?.classList.contains("open") &&
       !settingsMenu.contains(event.target) &&
-      !settingsButton.contains(event.target)
+      !settingsButton?.contains(event.target)
     ) {
       closeSettingsMenu();
     }
+  });
+
+  window.addEventListener("resize", () => {
+    document.querySelectorAll(".custom-select.open").forEach((select) => {
+      updateOptionsMaxHeight(select);
+    });
   });
 });

--- a/piggy/static/js/main.js
+++ b/piggy/static/js/main.js
@@ -5,12 +5,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const themeSelect = document.getElementById("theme-select");
   const fontSelect = document.getElementById("font-select");
+  const monoSelect = document.getElementById("mono-select")
   const fontSizeSelect = document.getElementById("font-size-select");
 
   const THEME_STORAGE_KEY = "theme";
   const FONT_STORAGE_KEY = "fontTheme";
+  const MONO_STORAGE_KEY = "monoTheme";
   const FONT_SIZE_STORAGE_KEY = "fontSize";
   const DEFAULT_FONT_THEME = "default";
+  const DEFAULT_MONO_THEME = "default";
   const DEFAULT_FONT_SIZE = "default";
 
   function closeAllCustomSelects(except = null) {
@@ -105,6 +108,11 @@ document.addEventListener("DOMContentLoaded", () => {
     document.documentElement.setAttribute("data-font-theme", fontTheme);
   }
 
+  function applyMonoTheme(monoTheme) {
+    localStorage.setItem(MONO_STORAGE_KEY, monoTheme);
+    document.documentElement.setAttribute("data-mono-theme", monoTheme);
+  }
+
   function applyFontSize(fontSize) {
     localStorage.setItem(FONT_SIZE_STORAGE_KEY, fontSize);
     document.documentElement.setAttribute("data-font-size", fontSize);
@@ -177,6 +185,13 @@ document.addEventListener("DOMContentLoaded", () => {
     defaultValue: DEFAULT_FONT_THEME,
     onChange: applyFontTheme,
   });
+
+  initializeCustomSelect({
+    select: monoSelect,
+    storageKey: MONO_STORAGE_KEY,
+    defaultValue: DEFAULT_MONO_THEME,
+    onChange: applyMonoTheme
+  })
 
   initializeCustomSelect({
     select: fontSizeSelect,

--- a/piggy/static/js/on-load.js
+++ b/piggy/static/js/on-load.js
@@ -8,6 +8,10 @@ const systemPreferredTheme =
 // Initialize theme and font settings asap
 const currentTheme = localStorage.getItem("theme") || systemPreferredTheme;
 const fontTheme = localStorage.getItem("fontTheme") || "default";
+const monoTheme = localStorage.getItem("monoTheme") || "default";
+const fontSize = localStorage.getItem("fontSize") || "normal";
 
 document.documentElement.setAttribute("data-theme", currentTheme);
 document.documentElement.setAttribute("data-font-theme", fontTheme);
+document.documentElement.setAttribute("data-mono-theme", monoTheme);
+document.documentElement.setAttribute("data-font-size", fontSize);

--- a/piggy/static/js/on-load.js
+++ b/piggy/static/js/on-load.js
@@ -9,7 +9,7 @@ const systemPreferredTheme =
 const currentTheme = localStorage.getItem("theme") || systemPreferredTheme;
 const fontTheme = localStorage.getItem("fontTheme") || "default";
 const monoTheme = localStorage.getItem("monoTheme") || "default";
-const fontSize = localStorage.getItem("fontSize") || "normal";
+const fontSize = localStorage.getItem("fontSize") || "default";
 
 document.documentElement.setAttribute("data-theme", currentTheme);
 document.documentElement.setAttribute("data-font-theme", fontTheme);

--- a/piggy/templates/partials/parts/settings.html
+++ b/piggy/templates/partials/parts/settings.html
@@ -8,8 +8,12 @@
   <!-- Close Button -->
   <a href="javascript:void(0)" class="close-button">&times;</a>
   <div class="settings-content">
-    <!-- Theme Selection -->
+    <br>
+    <h2>🎨 Themes & Colors</h2>
     {% include 'partials/parts/settings/theme.html' %}
+    <br>
+    <h2>🗛 Text options</h2>
+    {% include 'partials/parts/settings/font-size.html' %}
     {% include 'partials/parts/settings/font.html' %}
   </div>
 </div>

--- a/piggy/templates/partials/parts/settings.html
+++ b/piggy/templates/partials/parts/settings.html
@@ -15,5 +15,6 @@
     <h2>🗛 Text options</h2>
     {% include 'partials/parts/settings/font-size.html' %}
     {% include 'partials/parts/settings/font.html' %}
+    {% include 'partials/parts/settings/monospace-font.html' %}
   </div>
 </div>

--- a/piggy/templates/partials/parts/settings/font-size.html
+++ b/piggy/templates/partials/parts/settings/font-size.html
@@ -1,28 +1,31 @@
-<h3 class="settings-title">Font-size:</h3>
+<h3 class="settings-title">Font Size:</h3>
 <div class="custom-select" id="font-size-select">
     <div class="selected" data-value="">
         Normal
     </div>
     <div class="options-container">
-        <div class="option" data-value="normal" style="font-size: 0.75rem">
+        <div class="option" data-value="xx-small" style="font-size: 0.7rem">
             Tiny
         </div>
-        <div class="option" data-value="normal" style="font-size: 0.85rem">
+        <div class="option" data-value="x-small" style="font-size: 0.85rem">
             Smaller
         </div>
-        <div class="option" data-value="normal" style="font-size: 0.9rem">
+        <div class="option" data-value="small" style="font-size: 1.0rem">
             Small
         </div>
-        <div class="option" data-value="normal" style="font-size: 1rem">
+        <div class="option" data-value="default" style="font-size: 1.075rem">
             Normal
         </div>
-        <div class="option" data-value="normal" style="font-size: 1.25rem">
+        <div class="option" data-value="large" style="font-size: 1.2rem">
             Large
         </div>
-        <div class="option" data-value="normal" style="font-size: 1.5rem">
+        <div class="option" data-value="x-large" style="font-size: 1.35rem">
             Larger
         </div>
-        <div class="option" data-value="normal" style="font-size: 2.0rem">
+        <div class="option" data-value="xx-large" style="font-size: 1.5rem">
+            Massive
+        </div>
+        <div class="option" data-value="xxx-large" style="font-size: 1.85rem">
             Gigantic
         </div>
     </div>

--- a/piggy/templates/partials/parts/settings/font-size.html
+++ b/piggy/templates/partials/parts/settings/font-size.html
@@ -1,0 +1,29 @@
+<h3 class="settings-title">Font-size:</h3>
+<div class="custom-select" id="font-size-select">
+    <div class="selected" data-value="">
+        Normal
+    </div>
+    <div class="options-container">
+        <div class="option" data-value="normal" style="font-size: 0.75rem">
+            Tiny
+        </div>
+        <div class="option" data-value="normal" style="font-size: 0.85rem">
+            Smaller
+        </div>
+        <div class="option" data-value="normal" style="font-size: 0.9rem">
+            Small
+        </div>
+        <div class="option" data-value="normal" style="font-size: 1rem">
+            Normal
+        </div>
+        <div class="option" data-value="normal" style="font-size: 1.25rem">
+            Large
+        </div>
+        <div class="option" data-value="normal" style="font-size: 1.5rem">
+            Larger
+        </div>
+        <div class="option" data-value="normal" style="font-size: 2.0rem">
+            Gigantic
+        </div>
+    </div>
+</div>

--- a/piggy/templates/partials/parts/settings/font.html
+++ b/piggy/templates/partials/parts/settings/font.html
@@ -7,7 +7,7 @@
   <!-- Dropdown options -->
   <div class="options-container">
     <div class="option" data-value="default" style="font-family: 'Noto Sans', sans-serif;">
-      Default 🐷
+      Default (Default) 🐷
     </div>
     <div class="option" data-value="lexia" style="font-family: 'Lexia', sans-serif;">
       Lexia (Dyslexia friendly!) 👍

--- a/piggy/templates/partials/parts/settings/monospace-font.html
+++ b/piggy/templates/partials/parts/settings/monospace-font.html
@@ -1,11 +1,35 @@
-<h3 class="settings-title">Monospace Font:</h3>
-<div class="custom-select" id="monospace-font-select">
+<h3 class="settings-title">Code Font:</h3>
+<div class="custom-select" id="mono-select">
   <div class="selected" data-value="">
-    Select a monospace font
+    Select a code font
   </div>
   <div class="options-container">
-    <div class="option" data-value="default" style="font-family: 'Noto Sans', sans-serif;">
-      This is an option
+    <div class="option" data-value="default" style="font-family: 'Cascadia Code PL', monospace;">
+      Cascadia Code (Default) 💻
+    </div>
+    <div class="option" data-value="fira-code" style="font-family: 'Fira Code', monospace;">
+      Fira Code ⚙️
+    </div>
+    <div class="option" data-value="roboto-mono" style="font-family: 'Roboto Mono', monospace;">
+      Roboto Mono 🤖
+    </div>
+    <div class="option" data-value="jetbrains-mono" style="font-family: 'JetBrains Mono', monospace;">
+      JetBrains Mono 🧠
+    </div>
+    <div class="option" data-value="dm-mono" style="font-family: 'DM Mono', monospace;">
+      DM Mono 🎛️
+    </div>
+    <div class="option" data-value="ubuntu-mono" style="font-family: 'Ubuntu Mono', monospace;">
+      Ubuntu Mono 🐧
+    </div>
+    <div class="option" data-value="kode-mono" style="font-family: 'Kode Mono', monospace;">
+      Kode Mono 🧩
+    </div>
+    <div class="option" data-value="lucida" style="font-family: 'Lucida Console', monospace;">
+      Lucida Console 🖥️
+    </div>
+    <div class="option" data-value="courier" style="font-family: 'Courier New', monospace;">
+      Courier New 📠
     </div>
   </div>
 </div>

--- a/piggy/templates/partials/parts/settings/monospace-font.html
+++ b/piggy/templates/partials/parts/settings/monospace-font.html
@@ -1,0 +1,11 @@
+<h3 class="settings-title">Monospace Font:</h3>
+<div class="custom-select" id="monospace-font-select">
+  <div class="selected" data-value="">
+    Select a monospace font
+  </div>
+  <div class="options-container">
+    <div class="option" data-value="default" style="font-family: 'Noto Sans', sans-serif;">
+      This is an option
+    </div>
+  </div>
+</div>

--- a/piggy/templates/partials/parts/styles.html
+++ b/piggy/templates/partials/parts/styles.html
@@ -1,28 +1,18 @@
 {# Styles #}
-<link
-  href="{{ url_for('static', filename='css/styles.css') }}"
-  rel="stylesheet"
-/>
+<link href="{{ url_for('static', filename='css/styles.css') }}" rel="stylesheet" />
 
-<link
-  href="{{ url_for('static', filename='css/snout.css') }}"
-  rel="stylesheet"
-/>
+<link href="{{ url_for('static', filename='css/snout.css') }}" rel="stylesheet" />
 
-<link
-  href="{{ url_for('static', filename='css/tailwind.css') }}"
-  rel="stylesheet"
-/>
+<link href="{{ url_for('static', filename='css/tailwind.css') }}" rel="stylesheet" />
 
 {% for theme_file in themes %}
-  <link
-    href="{{ url_for('static', filename='css/themes/' + theme_file.path + '.css') }}"
-    rel="stylesheet"
-  />
+<link href="{{ url_for('static', filename='css/themes/' + theme_file.path + '.css') }}" rel="stylesheet" />
 {% endfor %}
 
 {# Google Fonts #}
-{% set gfont = "https://fonts.googleapis.com/css2?family=Baloo+2:wght@400..800&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Lexend:wght@100..900&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Noto+Sans+Math&family=Nunito:ital,wght@0,200..1000;1,200..1000&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Playpen+Sans:wght@100..800&family=Quicksand:wght@300..700&family=Noto+Color+Emoji&family=Fredoka:wght@300..700&family=Cherry+Bomb+One&family=Raleway:ital,wght@0,100..900;1,100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Bitter:ital,wght@0,100..900;1,100..900&display=swap" %}
+{% set gfont =
+"https://fonts.googleapis.com/css2?family=Baloo+2:wght@400..800&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Lexend:wght@100..900&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Noto+Sans+Math&family=Nunito:ital,wght@0,200..1000;1,200..1000&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Playpen+Sans:wght@100..800&family=Quicksand:wght@300..700&family=Noto+Color+Emoji&family=Fredoka:wght@300..700&family=Cherry+Bomb+One&family=Raleway:ital,wght@0,100..900;1,100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Bitter:ital,wght@0,100..900;1,100..900&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Kode+Mono:wght@400..700&family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Fira+Code:wght@300..700&display=swap"
+%}
 
 {# Preconnect for better performance #}
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -35,11 +25,6 @@
 {# Static Fonts (Preload) #}
 <link rel="preconnect" href="{{ url_for('static', filename='fonts/') }}" />
 {% for font in static_fonts_paths %}
-  <link
-    rel="preload"
-    href="{{ url_for('static', filename='fonts/' + font) }}"
-    as="font"
-    type="font/{{ font.split('.')[-1] }}"
-    crossorigin="anonymous"
-  />
+<link rel="preload" href="{{ url_for('static', filename='fonts/' + font) }}" as="font"
+  type="font/{{ font.split('.')[-1] }}" crossorigin="anonymous" />
 {% endfor %}


### PR DESCRIPTION
Following changes were made
- Made the main `styles.css` never use absolute font-sizes. It now uses a "font-scale" value. This allows for variable font sizes.
- Increased the default font size slightly.
- Increased the size of the "reading window" within assignments.
- Made the padding between the reading window and the rest of the page smaller.
    - This gives more screen real estate on smaller screens (mobile devices).
- A font size selection setting with 8 font size settings ranging from Tiny to Gigantic
    - The old font size has been delegated to "Small"
- A monospace (code) font selector that changes only the code font with the following fonts:
    - Cascadia Mono (default)
    - Fira Code
    - Roboto Mono
    - JetBrains Mono
    - DM Mono
    - Ubuntu Mono (a bit buggy in some cases)
    - Kode Mono
    - Lucida Console
    - Courier New

Fixes:
- Removed a useless "font-size" that exists in every theme. This was removed to accommodate for the font-size selector. 